### PR TITLE
Refactor Glide to use KSP

### DIFF
--- a/BazaarPay/build.gradle
+++ b/BazaarPay/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-parcelize'
     id 'androidx.navigation.safeargs.kotlin'
-    id 'kotlin-kapt'
+    id 'com.google.devtools.ksp'
     id 'maven-publish'
 }
 
@@ -69,7 +69,7 @@ dependencies {
     implementation libs.squareup.retrofit.core
     implementation libs.squareup.retrofit.core
     implementation libs.glide.core
-    kapt libs.glide.compiler
+    ksp libs.glide.compiler
     implementation libs.dotsIndicator
     implementation(libs.loggingInterceptor) {
         exclude group: 'org.json', module: 'json'

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.navigation.safeargs) apply false
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ androidMinSdk = "17"
 androidPlugin = "7.1.3"
 androidxLifecycle = "2.5.0"
 androidxNavigation = "2.5.0"
-glide = "4.13.1"
+glide = "4.15.1"
 kotlin = "1.6.21"
 retrofit = "2.9.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,5 +47,5 @@ loggingInterceptor = { group = "com.github.ihsanbal", name = "LoggingInterceptor
 android-application = { id = "com.android.application", version.ref = "androidPlugin" }
 android-library = { id = "com.android.library", version.ref = "androidPlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-ksp = { id = "com.google.devtools.ksp", version = "1.6.21-1.0.5" }
+ksp = { id = "com.google.devtools.ksp", version = "1.6.21-1.0.6" }
 navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidxNavigation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,4 +47,5 @@ loggingInterceptor = { group = "com.github.ihsanbal", name = "LoggingInterceptor
 android-application = { id = "com.android.application", version.ref = "androidPlugin" }
 android-library = { id = "com.android.library", version.ref = "androidPlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version = "1.6.21-1.0.5" }
 navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidxNavigation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ squareup-retrofit-converter = { group = "com.squareup.retrofit2", name = "conver
 squareup-retrofit-core = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 
 # Other
-glide-compiler = { group = "com.github.bumptech.glide", name = "compiler", version.ref = "glide" }
+glide-compiler = { group = "com.github.bumptech.glide", name = "ksp", version.ref = "glide" }
 glide-core = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
 dotsIndicator = { group = "com.tbuonomo", name = "dotsindicator", version = "4.2" }
 loggingInterceptor = { group = "com.github.ihsanbal", name = "LoggingInterceptor", version = "3.1.0" }


### PR DESCRIPTION
### Description
This PR changes setup of the *Glide* image loading library to use the *KSP* version of its **annotation processor**, which was introduced in version `4.14.2` in response to a [feature request](https://github.com/bumptech/glide/issues/4492). According to the [KSP documentation](https://kotlinlang.org/docs/ksp-overview.html):
> Compared to [kapt](https://kotlinlang.org/docs/kapt.html), annotation processors that use KSP can run up to 2 times faster.

The aforementioned build-time reduction is only applicable if no other processors use *KAPT*. Fortunately, it is the case for the *BazaarPay*, and the project will benefit from the migration.

### Changes
The following steps have been taken to implement this change, all following the setup section of the [Glide documentation](https://bumptech.github.io/glide/doc/download-setup.html#kotlin---ksp):
1. Adding **KSP plugin** to the project.
2. Bumping version of Glide to at least `4.14.2`.
3. Changing dependency from Glide Compiler to KSP one.