### PR TITLE
Update AGP

### DIFF
--- a/BazaarPay/build.gradle
+++ b/BazaarPay/build.gradle
@@ -30,11 +30,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
     buildFeatures {
         viewBinding true

--- a/BazaarPay/build.gradle
+++ b/BazaarPay/build.gradle
@@ -7,9 +7,6 @@ plugins {
     id 'maven-publish'
 }
 
-final VERSION_NAME = "4.0.0"
-final VERSION_CODE = 18
-
 android {
     namespace 'ir.cafebazaar.bazaarpay'
     compileSdk libs.versions.androidCompileSdk.get() as int
@@ -17,8 +14,6 @@ android {
     defaultConfig {
         minSdk libs.versions.androidMinSdk.get() as int
         targetSdk libs.versions.androidTargetSdk.get() as int
-        versionCode VERSION_CODE
-        versionName VERSION_NAME
         multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -82,7 +77,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'ir.cafebazaar.BazaarPay'
             artifactId = project.getName()
-            version = project.android.defaultConfig.versionName
+            version = "4.0.0"
 
             afterEvaluate {
                 from components.release

--- a/BazaarPay/build.gradle
+++ b/BazaarPay/build.gradle
@@ -11,6 +11,7 @@ final VERSION_NAME = "4.0.0"
 final VERSION_CODE = 18
 
 android {
+    namespace 'ir.cafebazaar.bazaarpay'
     compileSdk libs.versions.androidCompileSdk.get() as int
 
     defaultConfig {

--- a/BazaarPay/src/main/AndroidManifest.xml
+++ b/BazaarPay/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="ir.cafebazaar.bazaarpay">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/directdebitactivating/banklist/DirectDebitBankListFragment.kt
+++ b/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/directdebitactivating/banklist/DirectDebitBankListFragment.kt
@@ -97,6 +97,7 @@ internal class DirectDebitBankListFragment : Fragment() {
                     ResourceState.Success -> {
                         openUrlWithResourceData(resource.data)
                     }
+                    else -> error("Invalid state of handleDataState:${resource.resourceState}")
                 }
             }
             dataLiveData.observe(viewLifecycleOwner, ::handleData)

--- a/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/directdebitonboarding/DirectDebitOnBoardingFragment.kt
+++ b/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/directdebitonboarding/DirectDebitOnBoardingFragment.kt
@@ -93,6 +93,7 @@ internal class DirectDebitOnBoardingFragment : Fragment() {
                         loading.gone()
                     }
                 }
+                else -> error("Invalid state of handleDataState:${resource.resourceState}")
             }
         }
     }

--- a/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/increasecredit/PaymentDynamicCreditFragment.kt
+++ b/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/increasecredit/PaymentDynamicCreditFragment.kt
@@ -143,11 +143,7 @@ internal class PaymentDynamicCreditFragment : Fragment() {
                 _creditOptionsArgs = requireNotNull(resource.data)
                 initView()
             }
-            else -> {
-                throw IllegalStateException(
-                    "Invalid state of handleDataState:${resource.resourceState}"
-                )
-            }
+            else -> error("Invalid state of handleDataState:${resource.resourceState}")
         }
     }
 

--- a/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/increasecredit/PaymentDynamicCreditFragment.kt
+++ b/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/increasecredit/PaymentDynamicCreditFragment.kt
@@ -127,6 +127,7 @@ internal class PaymentDynamicCreditFragment : Fragment() {
             ResourceState.Success -> {
                 resource.data?.let { requireContext().openUrl(it) }
             }
+            else -> error("Invalid state of handleDataState:${resource.resourceState}")
         }
     }
 

--- a/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/increasecredit/PaymentDynamicCreditFragment.kt
+++ b/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/increasecredit/PaymentDynamicCreditFragment.kt
@@ -144,7 +144,7 @@ internal class PaymentDynamicCreditFragment : Fragment() {
                 initView()
             }
             else -> {
-                IllegalStateException(
+                throw IllegalStateException(
                     "Invalid state of handleDataState:${resource.resourceState}"
                 )
             }

--- a/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/paymentmethods/PaymentMethodsFragment.kt
+++ b/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/paymentmethods/PaymentMethodsFragment.kt
@@ -234,6 +234,7 @@ internal class PaymentMethodsFragment : Fragment(), PaymentMethodsClickListener 
                 PaymentFlowState.MerchantInfo -> {
                     setupMerchantInfoViews(resource.data as MerchantInfo)
                 }
+                else -> error("Invalid state of handleDataState:${resource.resourceState}")
             }
         }
     }
@@ -268,6 +269,7 @@ internal class PaymentMethodsFragment : Fragment(), PaymentMethodsClickListener 
                 ResourceState.Error -> {
                     toastMessage(requireContext().getReadableErrorMessage(it.failure))
                 }
+                else -> error("Invalid state of handleDataState:${resource.resourceState}")
             }
         }
     }

--- a/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/thanks/PaymentThankYouPageFragment.kt
+++ b/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/screens/payment/thanks/PaymentThankYouPageFragment.kt
@@ -80,6 +80,7 @@ internal class PaymentThankYouPageFragment : Fragment() {
                 showSuccess(paymentThankYouSuccessModel)
             }
             ResourceState.Error -> showError(resource.failure)
+            else -> error("Invalid state of handleDataState:${resource.resourceState}")
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+    namespace 'ir.cafebazaar.bazaarpay.sample'
     compileSdk libs.versions.androidCompileSdk.get() as int
 
     defaultConfig {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,11 +23,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
     buildFeatures {
         viewBinding true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="ir.cafebazaar.bazaarpay.sample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ androidPlugin = "7.4.2"
 androidxLifecycle = "2.5.0"
 androidxNavigation = "2.5.0"
 glide = "4.13.1"
-kotlin = "1.6.21"
+kotlin = "1.8.10"
 retrofit = "2.9.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,5 +47,5 @@ loggingInterceptor = { group = "com.github.ihsanbal", name = "LoggingInterceptor
 android-application = { id = "com.android.application", version.ref = "androidPlugin" }
 android-library = { id = "com.android.library", version.ref = "androidPlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-ksp = { id = "com.google.devtools.ksp", version = "1.6.21-1.0.6" }
+ksp = { id = "com.google.devtools.ksp", version = "1.8.10-1.0.9" }
 navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidxNavigation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 androidCompileSdk = "31"
 androidTargetSdk = "31"
 androidMinSdk = "17"
-androidPlugin = "7.1.3"
+androidPlugin = "7.4.2"
 androidxLifecycle = "2.5.0"
 androidxNavigation = "2.5.0"
 glide = "4.13.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue May 10 11:46:56 IRDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue May 10 11:46:56 IRDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,3 @@ dependencyResolutionManagement {
 rootProject.name = "BazaarPay"
 include ':app'
 include ':BazaarPay'
-
-// TODO: Starting from Gradle 7.4, Version Catalog
-//  is stable and enabled by default.
-enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
This PR bumps versions of Gradle, AGP,  Kotlin plugin, and targeted JVM as follows:

| Version | From | To |
|--------|--------|--------|
| Gradle | 7.2 | 8.1 |
| AGP | 7.1.3 | 7.4.2 |
| Kotlin | 1.6.21 | 1.8.10 |
| JVM | 8 | 11 |

## Changes

1. Removed the Opt-In required for the *Version Catalog* as it is stable starting from Gradle 7.4 and higher.
2. Set the `namespace` in the module-level `build.gradle` file, rather than the `package` attribute in the manifest file. It is a [breaking change](https://developer.android.com/studio/preview/features#namespace-dsl) starting from AGP 8.0 and higher.
3. Removed `versionCode` and `versionName` from the BazaarPay's `build.gradle` since Android library modules do not require these two properties ([link](https://issuetracker.google.com/issues/154275579?pli=1#comment3), [link](https://stackoverflow.com/a/69405546)). Instead moved the library version directly to the `publishing` configuration.
4. Made all when statements exhaustive, which otherwise [generates compilation error](https://kotlinlang.org/docs/whatsnew16.html#stable-exhaustive-when-statements-for-enum-sealed-and-boolean-subjects) starting from Koltin 1.7.0.

## Motivation

Using the latest versions of Gradle and its plugins (mainly AGP and Kotlin) has the following benefits:

- **Performance improvement**
Both the Gradle team and plugin writers continuously improve the performance of builds. For example, [Kotlin plugin 1.8.20](https://kotlinlang.org/docs/whatsnew-eap.html#new-jvm-incremental-compilation-by-default-in-gradle) introduces a [new approach to incremental compilation](https://kotlinlang.org/docs/gradle-compilation-and-caches.html#a-new-approach-to-incremental-compilation). Or the [Worker API](https://docs.gradle.org/current/userguide/worker_api.html) introduced in [Gradle 5.6](https://docs.gradle.org/5.6/release-notes.html).
- **New features**
New versions provide new features that simplify the developer's life. Take [Version Catalog](https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog) as an example which became stable starting from [Gradle 7.4](https://docs.gradle.org/7.4/release-notes.html). Or new [Variant APIs](https://mediumv.com/androiddevelopers/new-apis-in-the-android-gradle-plugin-f5325742e614) that are stable in [APG 8.0](https://developer.android.com/studio/releases/gradle-plugin-roadmap#agp_80_mid-2022) and higher.
- **Easier transition**
Staying up-to-date also makes transitioning to the next major version easier since it keeps required changes minimum, and you'll get early deprecation warnings.
- **Compatibility**
Adding other tools and libraries sometimes requires the project to meet a minimum version of the AGP or Kotlin plugin. For example, *Compose Compiler* 1.4.0 [requires](https://developer.android.com/jetpack/androidx/releases/compose-kotlin) at least Kotlin 1.8.0.