### PR TITLE
Convert BazaarPayOptions to a regular class

### DIFF
--- a/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/BazaarPayOptions.kt
+++ b/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/BazaarPayOptions.kt
@@ -7,7 +7,7 @@ package ir.cafebazaar.bazaarpay
  * @property isInDarkMode enables *Dark Mode* for the UI elements of the payment flow, which are in *Light Mode* by default.
  * @property phoneNumber the default phone number to pre-fill the login screen's input field. It uses a `null` value by default, resulting in no pre-filled input.
  */
-data class BazaarPayOptions(
+class BazaarPayOptions(
     val checkoutToken: String,
     val isInDarkMode: Boolean = false,
     val phoneNumber: String? = null


### PR DESCRIPTION
This PR converts `BazaarPayOptions` from a data class to a regular class.

### Motivation

As Kotlin's new [API guidelines](https://github.com/Kotlin/api-guidelines/blob/main/docs/topics/jvm-api-guidelines-backward-compatibility.md#dont-use-data-classes-in-api) state, it's better not to use data classes in library APIs since almost any change makes the API binary incompatible.