### PR TITLE
Fix commit api problem and upgrade gradle verison

### DIFF
--- a/BazaarPay/build.gradle
+++ b/BazaarPay/build.gradle
@@ -11,6 +11,8 @@ final VERSION_NAME = "5.0.1"
 final VERSION_CODE = 22
 
 android {
+
+    namespace 'ir.cafebazaar.bazaarpay'
     compileSdk libs.versions.androidCompileSdk.get() as int
 
     defaultConfig {

--- a/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/data/payment/PaymentRemoteDataSource.kt
+++ b/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/data/payment/PaymentRemoteDataSource.kt
@@ -21,7 +21,7 @@ import ir.cafebazaar.bazaarpay.extensions.safeApiCall
 import ir.cafebazaar.bazaarpay.models.GlobalDispatchers
 import ir.cafebazaar.bazaarpay.utils.Either
 import kotlinx.coroutines.withContext
-import okhttp3.ResponseBody
+import retrofit2.Response
 
 internal class PaymentRemoteDataSource {
 
@@ -82,7 +82,7 @@ internal class PaymentRemoteDataSource {
 
     suspend fun commit(
         checkoutToken: String
-    ): Either<ResponseBody> {
+    ): Either<Response<Unit>> {
         return withContext(globalDispatchers.iO) {
             return@withContext safeApiCall(ServiceType.BAZAARPAY) {
                 paymentService.commit(

--- a/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/data/payment/api/PaymentService.kt
+++ b/BazaarPay/src/main/java/ir/cafebazaar/bazaarpay/data/payment/api/PaymentService.kt
@@ -13,11 +13,11 @@ import ir.cafebazaar.bazaarpay.data.payment.models.pay.response.IncreaseBalanceO
 import ir.cafebazaar.bazaarpay.data.payment.models.pay.response.InitCheckoutResponse
 import ir.cafebazaar.bazaarpay.data.payment.models.pay.response.PayResponse
 import ir.cafebazaar.bazaarpay.data.payment.models.pay.response.TraceResponse
-import okhttp3.ResponseBody
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Query
+import retrofit2.Response
 
 internal interface PaymentService {
 
@@ -47,7 +47,7 @@ internal interface PaymentService {
     @POST("pardakht/badje/v1/commit/")
     suspend fun commit(
         @Body commitRequest: CommitRequest
-    ): ResponseBody
+    ): Response<Unit>
 
     @POST("pardakht/badje/v1/trace/")
     suspend fun trace(

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,9 @@ plugins {
 }
 
 android {
+
+    namespace 'ir.cafebazaar.bazaarpay.sample'
+
     compileSdk libs.versions.androidCompileSdk.get() as int
 
     defaultConfig {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 androidCompileSdk = "31"
 androidTargetSdk = "31"
 androidMinSdk = "17"
-androidPlugin = "7.1.3"
+androidPlugin = "8.0.1"
 androidxLifecycle = "2.5.0"
 androidxNavigation = "2.5.0"
 glide = "4.15.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue May 10 11:46:56 IRDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,3 @@ dependencyResolutionManagement {
 rootProject.name = "BazaarPay"
 include ':app'
 include ':BazaarPay'
-
-// TODO: Starting from Gradle 7.4, Version Catalog
-//  is stable and enabled by default.
-enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
Handle `KotlinNullPointerException` of commit api by changing its return type to `Response<Unit>`.
When we receive 204 as response code, `KotlinNullPointerException` is throws due to empty response body. This is handled by replacing `ResponseBody` with `Response<Unit>`.